### PR TITLE
GKN-242: Permit props in one line in declaration of function component

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -31,6 +31,14 @@ rules:
         - JSXText
         - JSXEmptyExpression
         - JSXSpreadChild
+  object-curly-newline:
+    - error
+    - ObjectExpression:
+        minProperties: 6
+        multiline: true
+      ObjectPattern:
+        minProperties: 6
+        multiline: true
   "react/jsx-first-prop-new-line": [1, multiline]
   "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
   "react/jsx-wrap-multilines": [1, { "logical": "ignore" }]


### PR DESCRIPTION
Указанная в тикете запись контролируется правилом object-curly-newline. У нее есть 4 случая применения, я не стал подробно разбираться, какой из них за что отвечает, просто опытным путем обнаружил, что наш случай работает правильно, если указаны и ObjectExpression и ObjectPattern одновременно. Возможно под него попадают еще какие-то ситуации, в которых нам запись в строчку разрешать не надо, но я посчитал, что дальнейшее вгрызание в проблему уже не окупится. Если что, вернемся к ней.

Разрешил однострочную запись, если:
а) между фигурными скобками нет переносов строк,
б) количество элементов не превышает 5.