### PR TITLE
GFM-144: Ошибка при попытке сохранить фильтры незалогиненным пользователем

### DIFF
--- a/src/v2/components/FilterBlock/FilterBlock.js
+++ b/src/v2/components/FilterBlock/FilterBlock.js
@@ -92,14 +92,14 @@ class FilterBlock extends Component {
     if (user) {
       filter = R.find(R.propEq('id', 'liked'))(R.values(filters));
       newFilters['liked'] = filter.selected;
+      R.forEach(
+        (resultKey) => {
+          filter = R.find(R.propEq('id', resultKey))(R.values(filters));
+          newFilters[resultKey] = filter.selected;
+        },
+        R.keys(RESULT_FILTERS),
+      );
     }
-    R.forEach(
-      (resultKey) => {
-        filter = R.find(R.propEq('id', resultKey))(R.values(filters));
-        newFilters[resultKey] = filter.selected;
-      },
-      R.keys(RESULT_FILTERS),
-    )
     setSelectedFilterProp(spotId, sectorId, newFilters);
     setSelectedPageProp(spotId, sectorId, 1);
   };


### PR DESCRIPTION
Это скорее временный фикс, чем окончательное решение проблемы. Этот фикс нужен, чтобы сохранить работоспособность после https://github.com/bitia-ru/gekkon-m-frontend/pull/145

Но после этого нужно еще вот что:
Идея в том, что у нас есть некоторое количество фильтров, которые надо показывать и применять только залогиненным пользователям, но сейчас нигде не хранится инфа о том какие фильтры показывать, а какие нет. В итоге получается, что при отображении фильтров и при формировании запроса к бекенду прописаны if-ы, которые определяют какие фильтры нужны в данный момент. Соответственно получается, что можно поменять код в одном месте и не поменять в другом, в итоге возникают ошибки.

Добавление сброса всех фильтров решает несколько другую проблему, оно решает какие данные у нас в данный момент могут оказаться в выбранных фильтрах, но фильтр может быть не выбран (использоваться дефолтный), а отображаться все равно должен. Кроме того сейчас все фильтры лежат в одном объекте, а отображаются в трех select-box-ах, т.е. нельзя просто взять список фильтров, который есть и по нему вычислить, что показывать, а что нет (точнее можно, но это будет довольно сомнительное решение)

Хотелось бы локализовать логику примерения и отображения фильтров в одном месте кода, и сделать более универсальной. Т.е. чтобы компонент, который отображает фильтры не сам определял, какие фильтры ему в данном случае отображать залогиненному пользователю, а какие не отображать, а ему передавался вместе с фильтром флаг, по которому он будет это определять. И так, чтобы при формировании запроса к бекенду использовался тот же флаг.

В этом контексте есть предложение переделать список дефолтных фильтров, на объект, который будет по ключу выдавать дефолтное значение фильтра, валидатор фильтра, флаг показывать или нет данный фильтр юзеру или всем, можно еще добавить флаг, по которому определять, что это один из фильров multiselect-box-а. Такую переделку можно сделать после тикета на добавление валидации (https://github.com/bitia-ru/gekkon-m-frontend/pull/142). Это не окончательный вариант решения, а скорее предложение. Идея в том, чтобы работа с фильтрами не была размазана по всему проекту, это упростит добавление новых фильтров, если таковые понадобятся