### PR TITLE
GFM-150: На iOS, в полях ввода номера и заголовка трассы текст скрывается за пределами полей.

### DIFF
--- a/src/v1/components/RouteDataTable/RouteDataTable.css
+++ b/src/v1/components/RouteDataTable/RouteDataTable.css
@@ -47,6 +47,7 @@
     display: inline-block;
     line-height: 35px;
     height: 35px;
+    padding: 1px 2px;
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
Fix #150 