### PR TITLE
GFM-150: На iOS, в полях ввода номера и заголовка трассы текст скрывается за пределами полей.

### DIFF
--- a/src/v2/components/RoutesEditModal/RoutesEditModal.js
+++ b/src/v2/components/RoutesEditModal/RoutesEditModal.js
@@ -626,6 +626,7 @@ const styles = StyleSheet.create({
     display: 'inline-block',
     lineHeight: '35px',
     height: '35px',
+    padding: '1px 2px',
     boxSizing: 'border-box',
     ':hover': { borderBottom: '2px solid #E3E3E3' },
   },


### PR DESCRIPTION
Fix #150