### PR TITLE
GFM-153: После сохранения трассы кроп слетает

### DIFF
--- a/src/v2/components/RoutePhotoCropper/RoutePhotoCropper.js
+++ b/src/v2/components/RoutePhotoCropper/RoutePhotoCropper.js
@@ -33,7 +33,6 @@ export default class RoutePhotoCropper extends Component {
         this.setState({ src: res.toDataURL('image/jpeg') });
       },
       {
-        maxWidth: this.imageContainerRef.clientWidth / 2,
         canvas: true,
         pixelRatio: 1,
         orientation: true,


### PR DESCRIPTION
Тикет не проверен на реальном мобильном устройстве, только в браузере в режиме мобильника

После перехода на wall_photos возникает ошибка, если запускать фронт локально, насколько я понимаю, ошибка связанна с cors. В хроме ошибка выглядит как Uncaught TypeError: res.toDataURL is not a function, в лисе DOMException: Failed to execute 'toDataURL' on 'HTMLCanvasElement': Tainted canvases may not be exported. Т.е. корреткно загрузка фото теперь работает только если фронт и бекенд запущены на одном хосте.