### PR TITLE
GFM-164: Не работает крестик в окне просмотра трассы

### DIFF
--- a/src/v2/modules/modalable/index.jsx
+++ b/src/v2/modules/modalable/index.jsx
@@ -93,7 +93,7 @@ const withModals = (BaseComponent) => {
         const hash = location.hash.slice(1);
 
         if (hash && super.modals()[hash]) {
-          history.replace({ pathname: location.pathname, hash: '' });
+          history.goBack();
         }
       });
     };


### PR DESCRIPTION
Крестик не срабатывал не вообще, он не срабатывал с первого раза. Проблема заключалась вот в чем:
1) открываем окно просмотра трассы - в history добавляется роут окна просмотра
2) открываем окно пролазов, это делается через push, поэтому в history добавляется еще и окно пролазов
3) крестик в окне пролазов делает replace роута с ```#ascents``` на роут без ```#ascents``` (так прописано в modalable, т.е. так работают все окна, которые открываются/закрываются через добавление/удаление хеша к роуту), в итоге в history оказывается роут просмотра трассы дважды
4) первое нажатие на крестик оставляет в history один роут просмотра трассы, второе - закрывает просмотр трассы

Мне кажется, что так как модальные окна, которые открываются через добавление к роуту хеша, сечас открываются через history.push, закрытие модальных окон логично делать через goBack, а не через replace