### PR TITLE
GFM-209: Add autocomplete off for Profile window

### DIFF
--- a/src/v1/components/FormField/FormField.js
+++ b/src/v1/components/FormField/FormField.js
@@ -12,7 +12,7 @@ export default class FormField extends Component {
 
     render() {
       const {
-        id, type, disabled, hasError, value, onChange, placeholder, errorText,
+        id, type, disabled, hasError, value, onChange, placeholder, errorText, autocomplete,
       } = this.props;
       return (
         <div className={`form__field${hasError ? ' form__field-error' : ''}`}>
@@ -26,6 +26,7 @@ export default class FormField extends Component {
               onChange={onChange}
               onKeyPress={this.onKeyPress}
               placeholder={placeholder}
+              autocomplete={autocomplete}
             />
             <label
               htmlFor={id}
@@ -61,6 +62,7 @@ FormField.propTypes = {
     PropTypes.string.isRequired,
     PropTypes.number.isRequired,
   ]),
+  autocomplete: PropTypes.string,
 };
 
 FormField.defaultProps = {
@@ -70,4 +72,5 @@ FormField.defaultProps = {
   disabled: false,
   onChange: null,
   errorText: null,
+  autocomplete: null,
 };

--- a/src/v2/forms/Profile/Profile.js
+++ b/src/v2/forms/Profile/Profile.js
@@ -371,6 +371,8 @@ class Profile extends Component {
                     </div>
                   </div>
                   <div className={css(styles.modalBlockMPaddingWrapper)}>
+                    <input type="text" style={{display: 'none'}} />
+                    <input type="password" style={{display: 'none'}} />
                     <FormField
                       placeholder="Имя"
                       id="name"
@@ -397,6 +399,7 @@ class Profile extends Component {
                       hasError={this.hasError('password')}
                       errorText={this.errorText('password')}
                       value={password}
+                      autocomplete="new-password"
                     />
                     <FormField
                       placeholder="Подтверждение пароля"
@@ -406,6 +409,7 @@ class Profile extends Component {
                       hasError={this.hasError('repeatPassword')}
                       errorText={this.errorText('repeatPassword')}
                       value={repeatPassword}
+                      autocomplete="new-password"
                     />
                     <FormField
                       placeholder="Email"


### PR DESCRIPTION
В Firefox в режиме мобильника наблюдался эффект, что при окрытии окна профиля сначала в двух верхних полях (имя и логин) появлялись правильные данные, а спустя несколько секунд там оказывалось что-то странное типа в одном число, в другом дата, но чему соответствует это число, а чему дата не особо понятно. Добавление двух невидимых полей эту проблему решают